### PR TITLE
docs(claude): add rule forbidding work on main branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,6 +78,7 @@ version: v1.1.0 # x-release-please-version
 
 29. Create a GitHub Issue for the task. If creation is forbidden in this context, skip it.
 30. Work in a dedicated branch for the issue.
-31. Push and create a Pull Request. If creation is forbidden in this context, skip it.
-32. Watch PR events. Try to fix conflicts — a rebase can help.
-33. Wait for the user to merge the Pull Request.
+31. Never work on `main` branch. No commits, no pushes — always use a dedicated branch.
+32. Push and create a Pull Request. If creation is forbidden in this context, skip it.
+33. Watch PR events. Try to fix conflicts — a rebase can help.
+34. Wait for the user to merge the Pull Request.


### PR DESCRIPTION
## Summary

- Adds rule 31 to the GitHub section of `CLAUDE.md`: never work on `main` — no commits, no pushes, always use a dedicated branch.
- Renumbers subsequent rules (32–34).

## Rationale

- Reinforces the existing rule 30 ("Work in a dedicated branch for the issue") with an explicit prohibition.
- Prevents accidental commits or pushes directly to `main`.