### PR TITLE
chore: prepare public-repo scaffolding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,41 @@
+name: Bug report
+description: Report something that isn't working as expected.
+labels: [bug]
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: What went wrong, in one or two sentences.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps to trigger the bug.
+      placeholder: |
+        1. ...
+        2. ...
+        3. ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Claude Code version, OS, anything else relevant.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,25 @@
+name: Feature request
+description: Propose a new rule, workflow, or improvement.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What's the underlying need or friction?
+    validations:
+      required: true
+  - type: textarea
+    id: outcome
+    attributes:
+      label: Desired outcome
+      description: What should be true after this change lands?
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you thought about and why you discarded them.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+Closes #
+
+## Summary
+
+- 
+
+## Test Plan
+
+- [ ] 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,34 @@
+# Contributing
+
+Thanks for your interest. This repo follows a tight, issue-driven workflow. The full ruleset lives in [CLAUDE.md](CLAUDE.md); this doc is the short version for contributors.
+
+## Before You Start
+
+- Open an issue (or claim an existing one) describing the change.
+- Small fixes (typos, clear bugs) can skip the issue, but a PR is still required.
+
+## Branching
+
+- One branch per issue.
+- Naming: `<type>/<issue-number>-<slug>` — e.g. `feat/12-add-x`, `fix/34-typo-in-readme`.
+- Never commit directly to `main`.
+
+## Commits
+
+- Follow [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/).
+- See [CLAUDE.md](CLAUDE.md) for allowed `types`, scope conventions, and the breaking-change format.
+- Atomic: one logical concern per commit. Don't mix unrelated changes.
+- No AI attribution or co-authoring trailers.
+
+## Pull Requests
+
+- Title uses Conventional Commits (same format as commits).
+- Body includes `Closes #<issue-number>`.
+- Keep scope tight — open a separate PR for unrelated work.
+- Maintainer merges; do not self-merge.
+
+## Releases
+
+- Fully automated via [release-please](https://github.com/googleapis/release-please).
+- `feat:` bumps minor, `fix:` bumps patch, `BREAKING CHANGE:` bumps major.
+- Don't edit `CHANGELOG.md`, the version in `CLAUDE.md` frontmatter, or `.release-please-manifest.json` by hand — release-please owns them.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 KingOfKalk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
Closes #7

## Summary

- `LICENSE` — MIT, copyright 2026 KingOfKalk
- `CONTRIBUTING.md` — short contributor guide; points to `CLAUDE.md` for the authoritative ruleset
- `.github/PULL_REQUEST_TEMPLATE.md` — prefills `Closes #`, Summary, Test Plan
- `.github/ISSUE_TEMPLATE/bug_report.yml` + `feature_request.yml` — structured GitHub forms
- `.github/ISSUE_TEMPLATE/config.yml` — keeps the blank-issue option alongside the templates

Three atomic commits, one logical concern each:

1. `chore: add LICENSE (MIT)`
2. `docs: add CONTRIBUTING guide`
3. `chore(github): add issue and PR templates`

Description + topics will be set via `gh repo edit` after merge.

## Test Plan

- [x] GitHub renders LICENSE and detects it as MIT (sidebar)
- [x] `CONTRIBUTING.md` link shows up on the "New issue" / "New PR" pages
- [x] Bug + feature templates appear in the issue picker
- [x] Opening a PR prefills the template body
- [x] Blank issues still openable