### PR TITLE
feat: add web env setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,8 @@
 
 My very basic Claude setup.
 See [CLAUDE.md](CLAUDE.md).
+
+## Claude Code
+
+A script to ensure the web environments have my CLAUDE.md as well system wide.
+See [web_env_setup.sh](./claude_code/web_env_setup.sh).

--- a/claude_code/web_env_setup.sh
+++ b/claude_code/web_env_setup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -euo pipefail
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+git clone --depth 1 "https://${GH_TOKEN}@github.com/KingOfKalk/claude.git" "$TMP"
+mkdir -p ~/.claude
+cp "$TMP/CLAUDE.md" ~/.claude/CLAUDE.md


### PR DESCRIPTION
Closes #9

## Summary

- `claude_code/web_env_setup.sh` — clones the repo via `\$GH_TOKEN` and copies `CLAUDE.md` into `~/.claude/CLAUDE.md`. For Claude Code web/cloud environments to inherit the same rules as local.
- `README.md` — new `## Claude Code` section pointing at the script.

## Test Plan

- [ ] Run the script in a fresh environment with `GH_TOKEN` set — confirm `~/.claude/CLAUDE.md` ends up as the repo's `CLAUDE.md`.
- [ ] Run without `GH_TOKEN` — script fails fast (due to `set -u`).
- [ ] README renders the new section and the link resolves.