### PR TITLE
feat(release): include docs in changelog

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,14 @@
     ".": {
       "release-type": "simple",
       "include-v-in-tag": true,
-      "extra-files": ["CLAUDE.md"]
+      "extra-files": ["CLAUDE.md"],
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance Improvements" },
+        { "type": "revert", "section": "Reverts" },
+        { "type": "docs", "section": "Documentation" }
+      ]
     }
   }
 }


### PR DESCRIPTION
Closes #14

## Summary

- Extends `release-please-config.json` with `changelog-sections` so `docs:` commits appear in `CHANGELOG.md` under a new *Documentation* section.
- Re-lists the standard sections (`feat` → Features, `fix` → Bug Fixes, `perf` → Performance Improvements, `revert` → Reverts) so they stay visible — release-please replaces defaults when `changelog-sections` is provided.

## Caveat

release-please does not bump the version on `docs:` alone (hardcoded in its parser). `docs:` entries only surface in the changelog when the next `feat:`/`fix:` triggers a release. Discussed and accepted.

## Test Plan

- [ ] Next release PR that includes a `docs:` commit since the last release shows a "Documentation" section.
- [ ] `feat:`/`fix:` sections continue to render as before.