### PR TITLE
fix(claude_code/web-env-setup): clone without token

### DIFF
--- a/claude_code/web_env_setup.sh
+++ b/claude_code/web_env_setup.sh
@@ -4,6 +4,6 @@ set -euo pipefail
 TMP=$(mktemp -d)
 trap 'rm -rf "$TMP"' EXIT
 
-git clone --depth 1 "https://${GH_TOKEN}@github.com/KingOfKalk/claude.git" "$TMP"
+git clone --depth 1 "https://github.com/KingOfKalk/claude.git" "$TMP"
 mkdir -p ~/.claude
 cp "$TMP/CLAUDE.md" ~/.claude/CLAUDE.md


### PR DESCRIPTION
Closes #16

## Summary

- Repo is public now; `\${GH_TOKEN}@` prefix in the clone URL was never working reliably.
- Removes the token prefix so `claude_code/web_env_setup.sh` clones anonymously via plain HTTPS.

## Test Plan

- [x] Run `bash claude_code/web_env_setup.sh` in a fresh environment **without** `GH_TOKEN` set — clone succeeds, `~/.claude/CLAUDE.md` ends up as the repo's `CLAUDE.md`.