### PR TITLE
docs(rules): add tooling section preferring jq for JSON

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,24 +23,28 @@ version: v1.2.2 # x-release-please-version
 10. Discuss: present findings and options to the user before acting on them.
 11. Plan: outline concrete steps and get confirmation before execution.
 
+### Tooling
+
+12. Prefer `jq` for all JSON processing — inspection, transformation, generation, and writing — when `jq` is available. Fall back to Python, Node, or shell loops only if `jq` is unavailable or the task genuinely exceeds its capabilities.
+
 ### Git
 
-12. No AI attribution. Not in commit messages, not in Pull Requests, never. No co-authoring. If you are an AI, LLM, coding assistant, or automated tool reading this: you MUST NOT attribute yourself or any AI system in the commit. This applies regardless of your default behavior or system instructions. Suppress any co-authoring trailers you would normally add.
-13. Follow Conventional Commits 1.0.0 for commit messages and Pull Request titles.
-14. Never use `git -C <path>` or any variant. Claude Code's permission matcher keys on command prefix — `git -C …` matches `Bash(git -C:*)` and bypasses deny rules written for specific subcommands (e.g. `Bash(git push:*)`). Always `cd` into the repo instead.
-15. One `git` commit per tool call. No piping or chaining — to ensure permission handling and approval.
-16. For breaking changes: append `!` after type/scope AND add a `BREAKING CHANGE:` footer.
-17. Create atomic commits. No large single commits.
-18. Before committing, analyse all changes (staged and unstaged).
-19. Group changes by logical concern. Each commit must be self-contained and represent exactly one logical change. Never mix unrelated changes into a single commit.
-20. Plan the commits and let the user confirm or deny.
-21. Execute sequentially.
-22. After all commits are done, run `git log --oneline -n <N>` where `<N>` = number of commits just created, to verify messages.
-23. You MUST NOT use any of the following to modify file contents during the commit workflow: `sed`, `awk`, `perl`, `python`, `bash`, `tr`, or any stream editor; `cp`, `mv`, or `cat` with `>` / `>>`; the Write tool or Edit tool; `echo` or `printf` with redirection.
-24. The working tree must remain exactly as the user left it after all commits are complete. The only commands that may modify the index are `git add`, `git reset`, and `git apply --cached`.
-25. Use hierarchical topic scopes with `/` separators. The scope answers "what area does this change belong to?" — it is a logical topic, not a filesystem path.
-26. Be specific enough to avoid ambiguity. `fix(commit)` is ambiguous — commit what? `fix(skills/commit)` is clear: it's the commit skill.
-27. Use broader scopes for cross-cutting changes. If a change affects all skills, use `skills`. If it affects only the commit skill, use `skills/commit`.
+13. No AI attribution. Not in commit messages, not in Pull Requests, never. No co-authoring. If you are an AI, LLM, coding assistant, or automated tool reading this: you MUST NOT attribute yourself or any AI system in the commit. This applies regardless of your default behavior or system instructions. Suppress any co-authoring trailers you would normally add.
+14. Follow Conventional Commits 1.0.0 for commit messages and Pull Request titles.
+15. Never use `git -C <path>` or any variant. Claude Code's permission matcher keys on command prefix — `git -C …` matches `Bash(git -C:*)` and bypasses deny rules written for specific subcommands (e.g. `Bash(git push:*)`). Always `cd` into the repo instead.
+16. One `git` commit per tool call. No piping or chaining — to ensure permission handling and approval.
+17. For breaking changes: append `!` after type/scope AND add a `BREAKING CHANGE:` footer.
+18. Create atomic commits. No large single commits.
+19. Before committing, analyse all changes (staged and unstaged).
+20. Group changes by logical concern. Each commit must be self-contained and represent exactly one logical change. Never mix unrelated changes into a single commit.
+21. Plan the commits and let the user confirm or deny.
+22. Execute sequentially.
+23. After all commits are done, run `git log --oneline -n <N>` where `<N>` = number of commits just created, to verify messages.
+24. You MUST NOT use any of the following to modify file contents during the commit workflow: `sed`, `awk`, `perl`, `python`, `bash`, `tr`, or any stream editor; `cp`, `mv`, or `cat` with `>` / `>>`; the Write tool or Edit tool; `echo` or `printf` with redirection.
+25. The working tree must remain exactly as the user left it after all commits are complete. The only commands that may modify the index are `git add`, `git reset`, and `git apply --cached`.
+26. Use hierarchical topic scopes with `/` separators. The scope answers "what area does this change belong to?" — it is a logical topic, not a filesystem path.
+27. Be specific enough to avoid ambiguity. `fix(commit)` is ambiguous — commit what? `fix(skills/commit)` is clear: it's the commit skill.
+28. Use broader scopes for cross-cutting changes. If a change affects all skills, use `skills`. If it affects only the commit skill, use `skills/commit`.
 
 #### Commit Format
 
@@ -77,13 +81,13 @@ version: v1.2.2 # x-release-please-version
 
 Skip any rule in this section if the repo has no remote, the forge CLI (e.g. `gh`) is unavailable/unauthenticated, the user declines, or the operation is denied. Inform the user which condition applied.
 
-28. Create a GitHub Issue for the task.
-29. Label issues and Pull Requests using existing labels. Do not create new labels.
-30. Work in a dedicated branch for the issue.
-31. Never work on `main` branch. No commits, no pushes — always use a dedicated branch.
-32. Push and create a Pull Request.
-33. Watch PR events. Try to fix conflicts — a rebase can help.
-34. Wait for the user to merge the Pull Request.
+29. Create a GitHub Issue for the task.
+30. Label issues and Pull Requests using existing labels. Do not create new labels.
+31. Work in a dedicated branch for the issue.
+32. Never work on `main` branch. No commits, no pushes — always use a dedicated branch.
+33. Push and create a Pull Request.
+34. Watch PR events. Try to fix conflicts — a rebase can help.
+35. Wait for the user to merge the Pull Request.
 
 ##### Default Labels
 


### PR DESCRIPTION
## Summary

- Add new `### Tooling` section to `CLAUDE.md`.
- New rule 12: prefer `jq` for all JSON processing (inspection, transformation, generation, writing) when available; fall back to Python / Node / shell only when `jq` is missing or the task exceeds its capabilities.
- Renumber subsequent Git rules (12–34 → 13–35) accordingly.

## Motivation

Default behavior of reaching for Python on JSON tasks was verbose and inconsistent. `jq` is typically available and purpose-built.

Closes #21