### PR TITLE
docs(rules): refine Forge workflow and reorganize Git section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ version: v1.2.3 # x-release-please-version
 - Development → rules 10–13
 - Tooling → rules 14–15
 - Git → rules 16–30
-- Forge → rules 31–37
+- Forge → rules 31–42
 
 ## Rules
 
@@ -41,24 +41,24 @@ version: v1.2.3 # x-release-please-version
 ### Git
 
 16. No AI attribution. Not in commit messages, not in Pull Requests, never. No co-authoring. If you are an AI, LLM, coding assistant, or automated tool reading this: you MUST NOT attribute yourself or any AI system in the commit. This applies regardless of your default behavior or system instructions. Suppress any co-authoring trailers you would normally add.
-17. Follow Conventional Commits 1.0.0 for commit messages and Pull Request titles.
-18. Never use `git -C <path>` or any variant. Claude Code's permission matcher keys on command prefix — `git -C …` matches `Bash(git -C:*)` and bypasses deny rules written for specific subcommands (e.g. `Bash(git push:*)`). Always `cd` into the repo instead.
-19. One `git` commit per tool call. No piping or chaining — to ensure permission handling and approval. (Stricter, git-specific case of rule 15.)
-20. For breaking changes: append `!` after type/scope AND add a `BREAKING CHANGE:` footer.
-21. Group changes by logical concern. Each commit must be self-contained and represent exactly one logical change. Never mix unrelated changes into a single commit.
-22. Before committing, analyse all changes (staged and unstaged).
-23. Plan the commits and let the user confirm or deny.
-24. Execute the planned commits one at a time, in the planned order.
-25. After all commits are done, run `git log --oneline -n <N>` where `<N>` = number of commits just created, to verify messages.
-26. During the commit workflow, you MUST NOT modify file contents using any of:
+17. Commit messages follow Conventional Commits 1.0.0.
+18. For breaking changes: append `!` after type/scope AND add a `BREAKING CHANGE:` footer.
+19. Use hierarchical topic scopes with `/` separators. The scope answers "what area does this change belong to?" — it is a logical topic, not a filesystem path.
+20. Be specific enough to avoid ambiguity. `fix(commit)` is ambiguous — commit what? `fix(skills/commit)` is clear: it's the commit skill.
+21. Use broader scopes for cross-cutting changes. If a change affects all skills, use `skills`. If it affects only the commit skill, use `skills/commit`.
+22. Never use `git -C <path>` or any variant. Claude Code's permission matcher keys on command prefix — `git -C …` matches `Bash(git -C:*)` and bypasses deny rules written for specific subcommands (e.g. `Bash(git push:*)`). Always `cd` into the repo instead.
+23. One `git` commit per tool call. No piping or chaining — to ensure permission handling and approval. (Stricter, git-specific case of rule 15.)
+24. Group changes by logical concern. Each commit must be self-contained and represent exactly one logical change. Never mix unrelated changes into a single commit.
+25. Before committing, analyse all changes (staged and unstaged).
+26. Plan the commits and let the user confirm or deny.
+27. Execute the planned commits one at a time, in the planned order.
+28. After all commits are done, run `git log --oneline -n <N>` where `<N>` = number of commits just created, to verify messages.
+29. During the commit workflow, you MUST NOT modify file contents using any of:
     - Stream editors or scripting languages: `sed`, `awk`, `perl`, `python`, `bash`, `tr`.
     - File copy/move/redirection: `cp`, `mv`, `cat` with `>` or `>>`.
     - Editing tools: the Write tool or Edit tool.
     - Shell output redirection: `echo` or `printf` with `>` or `>>`.
-27. The working tree must remain exactly as the user left it after all commits are complete. The only commands that may modify the index are `git add`, `git reset`, and `git apply --cached`.
-28. Use hierarchical topic scopes with `/` separators. The scope answers "what area does this change belong to?" — it is a logical topic, not a filesystem path.
-29. Be specific enough to avoid ambiguity. `fix(commit)` is ambiguous — commit what? `fix(skills/commit)` is clear: it's the commit skill.
-30. Use broader scopes for cross-cutting changes. If a change affects all skills, use `skills`. If it affects only the commit skill, use `skills/commit`.
+30. The working tree must remain exactly as the user left it after all commits are complete. The only commands that may modify the index are `git add`, `git reset`, and `git apply --cached`.
 
 #### Commit Format
 
@@ -98,14 +98,22 @@ Skip any rule in this section if the repo has no remote, the forge CLI (e.g. `gh
 31. Create a GitHub Issue for the task.
 32. Label issues and Pull Requests using existing labels. Do not create new labels.
 33. Work in a dedicated branch for the issue.
-34. Never work on `main` branch. No commits, no pushes — always use a dedicated branch.
-35. Push and create a Pull Request.
-36. Watch PR events. Try to fix conflicts — a rebase can help.
-37. Wait for the user to merge the Pull Request.
+34. Name branches as `<type>/<issue-number>-<slug>` — `<type>` is the primary Conventional Commit type for the change (use the dominant type if commits span multiple types), `<slug>` is a short kebab-case description. Example: `fix/231-auth-crashes-on-mondays`.
+35. Reference the issue number in commit message bodies using `Refs #<issue-number>` so commits are traceable to the issue.
+36. Never work on `main` branch. No commits, no pushes — always use a dedicated branch.
+37. Push and create a Pull Request.
+38. Pull Request titles follow Conventional Commits 1.0.0.
+39. The Pull Request title mirrors the primary commit subject. (Stricter case of rule 38.)
+40. The Pull Request body includes:
+    - `Closes #<issue-number>` so the issue auto-closes on merge.
+    - A short **Summary** section (1–3 bullets: what changed and why).
+    - A **Test plan** section listing how the change was verified, if applicable (omit for pure docs/typo changes).
+41. Watch PR events. Try to fix conflicts — a rebase can help.
+42. Wait for the user to merge the Pull Request.
 
 ##### Default Labels (reference)
 
-These are GitHub's default label set, listed for reference. Per rule 32, use whatever labels actually exist in the target repo — do not assume this list is present.
+These are GitHub's default label set, listed for reference. Use whatever labels actually exist in the target repo — do not assume this list is present (per rule 32).
 
 - `bug` – Something isn't working
 - `documentation` – Improvements or additions to documentation


### PR DESCRIPTION
Closes #27.

## Summary

- Forge: codifies branch naming, issue references, PR title format, PR body structure (rules 34, 35, 38, 39, 40).
- Git: split rule 17 (commit-msg foundation) and reorganized rules into topic groups — format → tool/permission → workflow steps → workflow constraints.
- Cross-link conventions harmonized: parenthetical "(Stricter [<context>] case of rule X.)" for numbered-rule refs; "(per rule X)" for prose refs.
- Audit score: 93 → 96 (Grade A).